### PR TITLE
Usar el atributo data-* en vez de la clase anti-aede-checked

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -97,32 +97,32 @@ $(function () {
   },  
   
   meneame = function (regexps) {
-   $('span.showmytitle').not('.anti-aede-checked').each(function (i) {
+   $('span.showmytitle').not('[data-anti-aede-checked]').each(function (i) {
       var title = this.title
       element = $(this).parents('.news-body');
       if(element.length){
-        console.log('showmy');
+        //console.log('showmy');
         preCheckElement(regexps, element, title, i);
       }
-   }).addClass('anti-aede-checked');
+   }).attr('data-anti-aede-checked', '');
 
-   $('.comment-body>a').not('.anti-aede-checked').each(function(i){
+   $('.comment-body>a').not('[data-anti-aede-checked]').each(function(i){
       var title = $(this).attr('href'),
       element = $(this).parent();
       preCheckElement(regexps, element, title, i);
-    }).addClass('anti-aede-checked');
+    }).attr('data-anti-aede-checked', '');
   },
   twitter = function (regexps) {
    // Twitter by @Hanxxs http://pastebin.com/f04tPcsG
-   $('a.twitter-timeline-link').not('.anti-aede-checked').each(function (i) {
+   $('a.twitter-timeline-link').not('[data-anti-aede-checked]').each(function (i) {
       var title = this.title,
       element = $(this).parents('.stream-item');
       preCheckElement(regexps, element, title, i);
-   }).addClass('anti-aede-checked');
+   }).attr('data-anti-aede-checked', '');
   },
   facebook = function (regexps) {
     // Facebook by @paucapo
-    $('div.fsm').not('.anti-aede-checked').each(function (i) {
+    $('div.fsm').not('[data-anti-aede-checked]').each(function (i) {
       var title = $(this).text(),
       element = $(this).parents('a.shareLink');
       preCheckElement(regexps, element, title, i, {
@@ -130,7 +130,7 @@ $(function () {
       });
     }).addClass('aede-on');
 
-    $('.userContent a').not('.anti-aede-checked').each(function (i) {
+    $('.userContent a').not('[data-anti-aede-checked]').each(function (i) {
       var title = $(this).text(),
       element = $(this);
       preCheckElement(regexps, element, title, i, {
@@ -138,36 +138,36 @@ $(function () {
       });
     }).addClass('aede-on');
 
-    $('div.userContentWrapper div.fcg').not('.anti-aede-checked').each(function (i) {
+    $('div.userContentWrapper div.fcg').not('[data-anti-aede-checked]').each(function (i) {
       var title = $(this).text(),
       element = $(this).parents('div.mvm');
       preCheckElement(regexps, element, title, i, {
         display: 'block',
       });
-    }).addClass('anti-aede-checked');
+    }).attr('data-anti-aede-checked', '');
 
-    $('div.storyInnerWrapper span.caption').not('.anti-aede-checked').each(function (i) {
+    $('div.storyInnerWrapper span.caption').not('[data-anti-aede-checked]').each(function (i) {
       var title = $(this).text(),
       element = $(this).parents('div.shareRedesignContainer');
       preCheckElement(regexps, element, title, i);
-    }).addClass('anti-aede-checked');
+    }).attr('data-anti-aede-checked', '');
   },
 
   google = function (regexps) {
     // Google by @paucapo
-    $('a').not('.anti-aede-checked').each(function (i) {
+    $('a').not('[data-anti-aede-checked]').each(function (i) {
       var title = $(this).attr('href'),
       element = $(this).parents('li.g');
       preCheckElement(regexps, element, title, i);
-    }).addClass('anti-aede-checked');
+    }).attr('data-anti-aede-checked', '');
   },
   others = function (regexps) {
     // Others by @paucapo
-    $('a').not('.anti-aede-checked').each(function (i) {
+    $('a').not('[data-anti-aede-checked]').each(function (i) {
       var title = $(this).attr('href') + ' ' + $(this).text(),
       element = $(this);
       preCheckElement(regexps, element, title, i);
-    }).addClass('anti-aede-checked');
+    }).attr('data-anti-aede-checked', '');
   },
 
   preCheckElement = function (regexps, element, url, i, extraCss) {


### PR DESCRIPTION
Buenas,

Hay webs que no funcionan correctamente cuando le añdes una clase al tag <a> (al hacer clic no te llevan a ninguna parte) Por ejemplo en http://www.nexusmods.com/skyrim/mods/61218/? hay unos botones justo encima de la barra azul donde pone Description (Desc, Files, Images, etc) que dejan de funcionar cuando está este script activado debido a que se les añade la clase anti-aede-checked.

Para solucionarlo he modificado el script de forma que utilice un atributo tipo data-* de HTML5 en vez de añadir clases, con eso debería funcionar igual y evitar este tipo de problemas.

Ojo de todas formas con la parte de Facebook (líneas 123 a 139), se añade una clase "aede-on" que no sé para qué sirve (a primera vista diría que es un error y debería poner "anti-aede-checked") Lo he dejado como estaba, lo único que he cambiado ahí es que compruebe el atributo en vez de la clase en las líneas 125 y 133 pero a lo mejor es necesario hacer algún ajuste.

Un saludo.